### PR TITLE
Quietly ignore error when searching through children

### DIFF
--- a/atomacos/_mixin/_search.py
+++ b/atomacos/_mixin/_search.py
@@ -1,3 +1,4 @@
+import atomacos
 from atomacos import AXCallbacks
 
 
@@ -7,10 +8,12 @@ class SearchMethodsMixin(object):
         if target is None:
             target = self
 
-        if "AXChildren" not in target.ax_attributes:
+        try:
+            children = target.AXChildren
+        except (AttributeError, atomacos.Error):
             return
 
-        for child in target.AXChildren:
+        for child in children:
             yield child
             if recursive:
                 for c in self._generateChildren(child, recursive):


### PR DESCRIPTION
Closes #8 

Use same guard as atomac

https://github.com/pyatom/pyatom/blob/master/atomac/AXClasses.py#L657-L660